### PR TITLE
Add Pv2/Ultra recovery-point cut-off validator scripts

### DIFF
--- a/Pv2UltraRecoveryPointCutoffValidation/README.md
+++ b/Pv2UltraRecoveryPointCutoffValidation/README.md
@@ -1,0 +1,159 @@
+# Pv2UltraRecoveryPointCutoffValidation
+
+A pair of tiny "ticker" scripts that let you **prove exactly where an Azure Site
+Recovery recovery point cuts off your data** after a failover — so you can
+validate that a recovered VM contains data *only up to* the recovery-point time,
+and not any newer, over-shot data.
+
+## Quick Start
+
+Run the ticker on the **source VM**, on the **replicated data disk**, and leave
+it running. Then do a test failover to a recovery point and read the last line.
+
+**Windows guest**
+
+```powershell
+# Run on the SOURCE VM. Choose a FOLDER on the replicated DATA disk (e.g. F:), not C:.
+# The log file defaults to ticker.log inside that folder.
+powershell -ExecutionPolicy Bypass -File .\asr-rp-ticker.ps1 -Folder F:\asr-validate
+
+# Choose folder + file name + interval (seconds) explicitly:
+powershell -ExecutionPolicy Bypass -File .\asr-rp-ticker.ps1 -Folder F:\asr-validate -FileName ticker.log -IntervalSec 10
+
+# Or pass one full path (overrides -Folder/-FileName):
+powershell -ExecutionPolicy Bypass -File .\asr-rp-ticker.ps1 -Path F:\asr-validate\ticker.log
+```
+
+**Linux guest**
+
+```bash
+chmod +x asr-rp-ticker.sh
+
+# Choose a FOLDER on the replicated DATA disk mount. File defaults to ticker.log.
+./asr-rp-ticker.sh -d /mnt/asr-data/asr-validate
+
+# Choose folder + file name + interval explicitly:
+./asr-rp-ticker.sh -d /mnt/asr-data/asr-validate -f ticker.log -i 10
+
+# Or pass one full file path as a positional arg (overrides -d/-f):
+./asr-rp-ticker.sh /mnt/asr-data/asr-validate/ticker.log 10
+
+# Keep it running after you log out:
+nohup ./asr-rp-ticker.sh -d /mnt/asr-data/asr-validate >/dev/null 2>&1 &
+```
+
+Each line written is `<seq>,<utc-iso8601-ms>`, e.g. `842,2026-08-07T05:44:10.123Z`.
+
+## Problem
+
+Azure Site Recovery recovery points are **crash-consistent** block-level
+snapshots: they have a single, write-order-consistent cut-off across all of a
+VM's disks at the recovery-point time. On certain premium disk types
+(**PremiumV2_LRS / Ultra / Direct-Drive**), a defect could cause a recovered
+disk to contain writes that landed **slightly newer than the selected recovery
+point** ("recovery-point over-shoot"). After the fix, the recovered data must
+stop **at or before** the recovery-point time.
+
+The challenge for a customer is that ordinary application data gives no precise
+marker of "where did my data actually stop?". These scripts provide that marker:
+a durable, timestamped heartbeat written to the data disk every few seconds. The
+**last durable line that survives a failover is the true data cut-off**, which
+you compare against the recovery-point time shown in the portal.
+
+## How It Works
+
+The ticker opens the log file on the replicated data disk and, every `IntervalSec`
+seconds, appends one line and **forces it to physical disk** before continuing:
+
+* **Windows** — the file is opened `Append` + `FileOptions.WriteThrough`, and each
+  tick calls `FileStream.Flush($true)`, which issues **`FlushFileBuffers`**. The
+  line is on the platter (not just in the OS cache) before the next tick.
+* **Linux** — each tick appends the line and then calls **`sync <file>`** (falling
+  back to a global `sync`) to push the data through to the disk.
+
+Because every line is durable the instant it is written, the file's **last line at
+the crash-consistent cut-off is deterministic**: it reflects exactly what had
+reached disk at the recovery-point moment. The monotonically increasing `seq`
+counter lets you spot the exact cut-off index and detect any gaps.
+
+### Validation flow
+
+1. Start the ticker on the source VM (on the replicated data disk) and let
+   replication run long enough to build the recovery point you want to test.
+2. **Test-fail over** (recommended — non-disruptive) to a chosen recovery point.
+   Note the recovery-point **time** shown in the portal (it is UTC).
+3. On the recovered VM, read the **last line** of the ticker file:
+
+   ```powershell
+   # Windows (recovered VM)
+   Get-Content F:\asr-validate\ticker.log -Tail 1
+   ```
+
+   ```bash
+   # Linux (recovered VM)
+   tail -n 1 /mnt/asr-data/asr-validate/ticker.log
+   ```
+
+4. Compare the last timestamp against the recovery-point time.
+
+### How to interpret the result
+
+| Observation | Meaning |
+|---|---|
+| Last timestamp **≤ recovery-point time** (within ~one tick interval) | **Expected / fixed.** The recovered data cuts off at or before the recovery point. |
+| Last timestamp **meaningfully newer** than the recovery-point time | **Over-shoot.** The recovered disk contains data past the recovery point — capture the file and open a support case. |
+
+> **Note on "the database looks like it has newer rows":** a *running* service
+> (e.g. a DB) will **auto-start on the failover boot and write brand-new rows**.
+> Those post-boot writes are NOT recovered over-shoot. This ticker avoids that
+> confusion by design — it does not auto-restart on the recovered VM, so its last
+> line is purely the recovered cut-off. If you use your own app's data instead,
+> split rows at the VM boot time before judging over-shoot.
+
+## Configuration Details
+
+| Setting | Windows | Linux | Default |
+|---|---|---|:-:|
+| Log folder | `-Folder` | `-d` | `F:\asr-validate` / `/mnt/asr-data/asr-validate` |
+| Log file name | `-FileName` | `-f` | `ticker.log` |
+| Full log path (overrides folder+name) | `-Path` | positional arg 1 | *(built from folder + file name)* |
+| Write interval (seconds) | `-IntervalSec` | `-i` / positional arg 2 | `10` |
+
+* The log folder **must be on the replicated data disk** — not the OS disk, and not
+  the Azure ephemeral/resource disk (`D:` on Windows, usually `/mnt` on Linux is
+  the resource disk, so pick a real data-disk mount).
+* A 10-second interval keeps the file tiny (≈ 3 KB/hour) while bounding the
+  cut-off uncertainty to at most one interval. Lower it for a tighter marker.
+* The scripts run indefinitely until you stop them (Ctrl+C, or `kill` the
+  backgrounded Linux process). They flush and close cleanly on stop.
+
+## Testing
+
+Both scripts are self-contained writers with no dependencies beyond the OS shell.
+To smoke-test locally before deploying to a guest:
+
+```powershell
+# Windows: write to a temp folder for a bit, then Ctrl+C, and inspect
+powershell -ExecutionPolicy Bypass -File .\asr-rp-ticker.ps1 -Folder $env:TEMP\asr-validate -IntervalSec 2
+Get-Content $env:TEMP\asr-validate\ticker.log -Tail 5
+```
+
+```bash
+# Linux: write to /tmp for a bit, then Ctrl+C, and inspect
+./asr-rp-ticker.sh -d /tmp/asr-validate -i 2
+tail -n 5 /tmp/asr-validate/ticker.log
+```
+
+You should see continuous `<seq>,<utc>` lines with no gaps and a monotonic `seq`.
+
+## Files
+
+| File | Runs on | Purpose |
+|---|---|---|
+| `asr-rp-ticker.ps1` | Windows source VM | Durable 10s timestamp ticker (WriteThrough + FlushFileBuffers). |
+| `asr-rp-ticker.sh` | Linux source VM | Durable 10s timestamp ticker (per-line `sync`). |
+
+---
+
+These scripts are provided **as-is**, without warranty of any kind. See the
+repository `LICENSE.txt`.

--- a/Pv2UltraRecoveryPointCutoffValidation/asr-rp-ticker.ps1
+++ b/Pv2UltraRecoveryPointCutoffValidation/asr-rp-ticker.ps1
@@ -1,0 +1,74 @@
+<#
+    asr-rp-ticker.ps1  -  ASR recovery-point cut-off validator (Windows guest)
+
+    Writes one line every N seconds to a file on the REPLICATED DATA DISK and
+    forces each line to physical disk (WriteThrough + FlushFileBuffers) so the
+    LAST line in the file is guaranteed-durable at the crash-consistent cut-off.
+
+    After you fail over (or test-fail over) to a chosen recovery point, open this
+    file on the recovered VM and look at the LAST line: that timestamp is the
+    exact point the data was cut off. With the fix in place it must be <= the
+    recovery-point time. If it is meaningfully NEWER than the RP time, the RP
+    over-shot (recovered more data than the point represents).
+
+    Line format (CSV, no header):  <seq>,<utc-iso8601-ms>
+      seq  = monotonic counter (detect gaps / the exact cut-off index)
+      utc  = e.g. 2026-08-07T05:44:10.123Z  (UTC, matches portal RP times)
+
+    USAGE (run on the SOURCE VM; elevation not required):
+      # Pick a folder on the replicated DATA disk; file defaults to ticker.log:
+      powershell -ExecutionPolicy Bypass -File .\asr-rp-ticker.ps1 -Folder F:\asr-validate
+      # Or choose folder + file name explicitly:
+      powershell -ExecutionPolicy Bypass -File .\asr-rp-ticker.ps1 -Folder F:\asr-validate -FileName ticker.log
+      # Or give one full path (overrides -Folder/-FileName):
+      powershell -ExecutionPolicy Bypass -File .\asr-rp-ticker.ps1 -Path F:\asr-validate\ticker.log
+      # The folder MUST be on the replicated DATA disk (e.g. F:), NOT C: or the temp disk.
+      # Leave it running. Stop with Ctrl+C (it flushes and closes cleanly).
+
+    This script is provided as-is with no warranty (see repo LICENSE).
+#>
+param(
+    [string]$Folder = 'F:\asr-validate',
+    [string]$FileName = 'ticker.log',
+    [string]$Path,
+    [int]$IntervalSec = 10
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($IntervalSec -lt 1) { throw "IntervalSec must be >= 1." }
+
+# -Path (full path) wins; otherwise build it from -Folder + -FileName.
+if (-not $Path) { $Path = Join-Path $Folder $FileName }
+
+$dir = Split-Path -Parent $Path
+if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+
+# Append + WriteThrough so every Flush($true) issues FlushFileBuffers (durable to disk).
+$fs = [System.IO.FileStream]::new(
+    $Path,
+    [System.IO.FileMode]::Append,
+    [System.IO.FileAccess]::Write,
+    [System.IO.FileShare]::ReadWrite,
+    4096,
+    [System.IO.FileOptions]::WriteThrough)
+$sw = [System.IO.StreamWriter]::new($fs)
+$sw.AutoFlush = $false
+
+$seq = 0
+Write-Host "Ticker writing to $Path every $IntervalSec s. Press Ctrl+C to stop."
+try {
+    while ($true) {
+        $seq++
+        $utc = [DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
+        $sw.WriteLine(('{0},{1}' -f $seq, $utc))
+        $sw.Flush()          # flush managed buffer to OS
+        $fs.Flush($true)     # FlushFileBuffers -> durable to physical disk
+        Start-Sleep -Seconds $IntervalSec
+    }
+}
+finally {
+    try { $sw.Flush(); $fs.Flush($true) } catch {}
+    $sw.Dispose(); $fs.Dispose()
+    Write-Host "Ticker stopped. Last seq = $seq. File: $Path"
+}

--- a/Pv2UltraRecoveryPointCutoffValidation/asr-rp-ticker.sh
+++ b/Pv2UltraRecoveryPointCutoffValidation/asr-rp-ticker.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# asr-rp-ticker.sh  -  ASR recovery-point cut-off validator (Linux guest)
+#
+# Writes one line every N seconds to a file on the REPLICATED DATA DISK and
+# fsyncs each line to physical disk so the LAST line in the file is
+# guaranteed-durable at the crash-consistent cut-off.
+#
+# After you fail over (or test-fail over) to a chosen recovery point, open this
+# file on the recovered VM and look at the LAST line: that timestamp is the
+# exact point the data was cut off. With the fix in place it must be <= the
+# recovery-point time. If it is meaningfully NEWER than the RP time, the RP
+# over-shot (recovered more data than the point represents).
+#
+# Line format (CSV, no header):  <seq>,<utc-iso8601-ms>
+#   seq = monotonic counter ; utc = e.g. 2026-08-07T05:44:10.123Z (UTC)
+#
+# USAGE (run on the SOURCE VM):
+#   chmod +x asr-rp-ticker.sh
+#   # Pick a folder on the replicated DATA disk; file defaults to ticker.log:
+#   ./asr-rp-ticker.sh -d /mnt/asr-data/asr-validate
+#   # Or choose folder + file name + interval explicitly:
+#   ./asr-rp-ticker.sh -d /mnt/asr-data/asr-validate -f ticker.log -i 10
+#   # Or give one full file path as a positional arg (overrides -d/-f):
+#   ./asr-rp-ticker.sh /mnt/asr-data/asr-validate/ticker.log 10
+#   # The folder MUST be on the replicated DATA disk mount, NOT the OS disk or the
+#   # ephemeral resource disk (usually /mnt is the resource disk -> pick a real
+#   # data-disk mount).
+#
+# For an unattended run that survives your SSH session, use nohup:
+#   nohup ./asr-rp-ticker.sh -d /mnt/asr-data/asr-validate >/dev/null 2>&1 &
+#
+# This script is provided as-is with no warranty (see repo LICENSE).
+set -u
+
+DIR='/mnt/asr-data/asr-validate'
+NAME='ticker.log'
+INTERVAL='10'
+
+while getopts ':d:f:i:h' opt; do
+    case "$opt" in
+        d) DIR="$OPTARG" ;;
+        f) NAME="$OPTARG" ;;
+        i) INTERVAL="$OPTARG" ;;
+        h) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        :) echo "Option -$OPTARG requires an argument." >&2; exit 1 ;;
+        \?) echo "Unknown option -$OPTARG." >&2; exit 1 ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+# Positional back-compat:  arg1 = full file path, arg2 = interval.
+if [ "${1:-}" != "" ]; then FILE="$1"; else FILE="$DIR/$NAME"; fi
+if [ "${2:-}" != "" ]; then INTERVAL="$2"; fi
+
+case "$INTERVAL" in
+    ''|*[!0-9]*) echo "Interval must be a positive integer (seconds)." >&2; exit 1 ;;
+esac
+
+mkdir -p "$(dirname "$FILE")"
+seq=0
+trap 'echo; echo "Ticker stopped. Last seq = $seq. File: $FILE"; exit 0' INT TERM
+
+echo "Ticker writing to $FILE every ${INTERVAL}s. Press Ctrl+C to stop."
+while true; do
+    seq=$((seq + 1))
+    # GNU date: %3N = milliseconds. Falls back if %N is unsupported.
+    utc="$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf '%s,%s\n' "$seq" "$utc" >> "$FILE"
+    # Force this file's data to physical disk. Prefer per-file sync; fall back to global.
+    sync "$FILE" 2>/dev/null || sync
+    sleep "$INTERVAL"
+done


### PR DESCRIPTION
## What

Adds a new self-help scenario folder **`Pv2UltraRecoveryPointCutoffValidation`** with two tiny durable "ticker" scripts (Windows + Linux) plus a README.

They let a customer **prove exactly where an ASR recovery point cuts off their data** after failover, to validate the **PremiumV2_LRS / Ultra / Direct-Drive** recovery-point over-shoot fix.

## How it works

The ticker writes `<seq>,<utc-iso8601-ms>` to a file on the replicated data disk every N seconds (default 10) and forces each line to physical disk:
- **Windows** `asr-rp-ticker.ps1` — `FileStream` `Append` + `WriteThrough` and `Flush(\True)` (`FlushFileBuffers`) per tick.
- **Linux** `asr-rp-ticker.sh` — per-line `sync <file>` (fallback global `sync`).

After a (test) failover, the **last durable line** = the true data cut-off. Fix working ⇒ last timestamp ≤ recovery-point time; over-shoot ⇒ meaningfully newer.

## Configurable

Log **folder** / **file name** (or a full **path** override) and **interval** are all selectable — Windows `-Folder`/`-FileName`/`-Path`/`-IntervalSec`; Linux `-d`/`-f`/`-i` (positional full path + interval also supported).

## Validation

Smoke-tested the Windows ticker locally on Windows PowerShell 5.1: durable lines with correct format and ~interval cadence, surviving an abrupt process kill; verified folder/file selection. (Fixed a `WriteLine` arg-splitting bug found during testing.)

Scripts are provided as-is, consistent with the repo convention.